### PR TITLE
Expose data channel & client-flow methods (remote_description, add_transceiver)

### DIFF
--- a/src/webrtcredux/mod.rs
+++ b/src/webrtcredux/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use gst::glib;
 use gst::prelude::*;
 use gst::subclass::prelude::ObjectSubclassExt;
@@ -9,6 +11,8 @@ mod imp;
 
 pub use imp::*;
 use tokio::runtime::Handle;
+use webrtc::data_channel::RTCDataChannel;
+use webrtc::data_channel::data_channel_init::RTCDataChannelInit;
 use webrtc::ice_transport::ice_gatherer::OnICEGathererStateChangeHdlrFn;
 use webrtc::ice_transport::ice_gatherer::OnLocalCandidateHdlrFn;
 use webrtc::peer_connection::OnICEConnectionStateChangeHdlrFn;
@@ -128,6 +132,12 @@ impl WebRtcRedux {
     ) -> Result<(), ErrorMessage> {
         imp::WebRtcRedux::from_instance(self)
             .add_ice_candidate(candidate)
+            .await
+    }
+
+    pub async fn create_data_channel(&self, name: &str, init_params: Option<RTCDataChannelInit>) -> Result<Arc<RTCDataChannel>, ErrorMessage> {
+        imp::WebRtcRedux::from_instance(self)
+            .create_data_channel(name, init_params)
             .await
     }
 

--- a/src/webrtcredux/mod.rs
+++ b/src/webrtcredux/mod.rs
@@ -18,6 +18,8 @@ use webrtc::ice_transport::ice_gatherer::OnLocalCandidateHdlrFn;
 use webrtc::peer_connection::OnICEConnectionStateChangeHdlrFn;
 use webrtc::peer_connection::OnNegotiationNeededHdlrFn;
 use webrtc::peer_connection::OnPeerConnectionStateChangeHdlrFn;
+use webrtc::rtp_transceiver::RTCRtpTransceiverInit;
+use webrtc::rtp_transceiver::rtp_codec::RTPCodecType;
 
 use self::sdp::SDP;
 pub mod sdp;
@@ -53,6 +55,16 @@ impl WebRtcRedux {
         imp::WebRtcRedux::from_instance(self).set_stream_id(pad_name, stream_id)
     }
 
+    pub async fn add_transceiver(
+        &self,
+        codec_type: RTPCodecType,
+        init_params: &[RTCRtpTransceiverInit]) -> Result<Arc<RTCRtpTransceiver>, ErrorMessage>
+    {
+        imp::WebRtcRedux::from_instance(self)
+            .add_transceiver_from_kind(codec_type, init_params)
+            .await
+    }
+
     pub async fn create_offer(
         &self,
         options: Option<RTCOfferOptions>,
@@ -83,6 +95,10 @@ impl WebRtcRedux {
         imp::WebRtcRedux::from_instance(self)
             .set_local_description(sdp, sdp_type)
             .await
+    }
+
+    pub async fn remote_description(&self) -> Result<Option<SDP>, ErrorMessage> {
+        imp::WebRtcRedux::from_instance(self).remote_description().await
     }
 
     pub async fn set_remote_description(&self, sdp: &SDP, sdp_type: RTCSdpType) -> Result<(), ErrorMessage> {


### PR DESCRIPTION
Hey!

This PR exposes 3 additional methods from webrtc-rs to the WebrtcRedux consumer.

* `peer_connection.create_data_channel`, returning the native webrtc-rs `RTCDataChannel` which then can be used with callbacks like `datachannel.on_open` and `datachannel.on_message`
* `peer_connection.remote_description` - To check the status of incoming ICE candidates (based off: https://github.com/webrtc-rs/webrtc/blob/master/examples/examples/offer-answer/offer.rs#L251)
* `peer_connection.add_transceiver_from_kind` - To make PeerConnection aware of available channels to generate appropriate SDP offer.

Background:
I am currently working on a application that utilizes gst-webrtcredux for a consumer/client setup.

This means:
- Client creates the initial SDP offer
- Client adds transceivers before SDP offer gets created, so SDP contains the appropriate accepted payloads/codes
- Sometimes-pads `src_%u` need to be linked on `PeerConnection.on_track`-callback

PS: I would like to follow-up this with an example of h264-client, which would fetch audio/video via webbrowser and stream that to the gst-/webrtcredux client.

My current codebase implementing the client-flow is way too ugly to look at right now, being written by a rust beginner..

cheers and nice project btw :)

PPS: Something I don't really understand:


Despite explicity using `pub use` for these new imports, the are not available in the codebase utilizing the library...

```
pub use webrtc::data_channel::RTCDataChannel;
pub use webrtc::data_channel::data_channel_init::RTCDataChannelInit;
...
pub use webrtc::rtp_transceiver::{RTCRtpTransceiverInit, RTCRtpTransceiver};
pub use webrtc::rtp_transceiver::rtp_codec::{RTCRtpCodecCapability, RTPCodecType};
```

Anything else that needs to be taken care of here?